### PR TITLE
Feature/nova rate limits better filtering

### DIFF
--- a/nova_limits.py
+++ b/nova_limits.py
@@ -105,6 +105,9 @@ def nova_preprocess(midware, environ):
 
             # Decode the key and the bucket and store them
             params = ParamsDict(turns_lim.decode(key))
+            if 'tenant' in params and params['tenant'] != tenant:
+                continue
+
             bucket = turns_lim.bucket_class.hydrate(midware.db,
                                                     msgpack.loads(raw),
                                                     turns_lim, key)

--- a/nova_limits.py
+++ b/nova_limits.py
@@ -136,7 +136,7 @@ def nova_preprocess(midware, environ):
 
         # Now, build a representation of the limit
         for verb in verbs:
-            if len(buck_list) > 1:
+            if len(buck_list) >= 1:
                 # Generate one entry for each bucket
                 for params, bucket in buck_list:
                     # Substitute (some of) the values in params to
@@ -151,8 +151,8 @@ def nova_preprocess(midware, environ):
                             remaining=bucket.messages,
                             resetTime=bucket.expire,
                             ))
-
-            limits.append(dict(
+            else:
+                limits.append(dict(
                     verb=verb,
                     URI=uri,
                     regex=uri,

--- a/test_nova_limits.py
+++ b/test_nova_limits.py
@@ -413,15 +413,6 @@ class TestPreprocess(unittest.TestCase):
                     ),
                 dict(
                     verb='GET',
-                    URI='/spam/{uri3}/{param}',
-                    regex='/spam/{uri3}/{param}',
-                    value=50,
-                    unit='MINUTE',
-                    remaining=5,
-                    resetTime=1000000005,
-                    ),
-                dict(
-                    verb='GET',
                     URI='/spam/{uri4}/{param}',
                     regex='/spam/{uri4}/{param}',
                     value=50,
@@ -472,8 +463,8 @@ class TestPreprocess(unittest.TestCase):
         self.assertEqual(environ['nova.limits'], [
                 dict(
                     verb='GET',
-                    URI='/{tenant}/{uri}',
-                    regex='/{tenant}/{uri}',
+                    URI='/spam/{uri}',
+                    regex='/spam/{uri}',
                     value=5,
                     unit='MINUTE',
                     remaining=0,


### PR DESCRIPTION
I've done some changes that I think improve how `nova rate-limits` command show limits, so sending them back. I've also added some tools from Nova in order to build a virtualenv.
